### PR TITLE
Journey planning basics and HTML output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,4 +10,5 @@ in progress
 2023-08-xx 0.0.0
 ================
 
-- Initial thing.
+- Initial thing
+- Journey planning basics and HTML output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ classifiers = [
 dependencies = [
   "click<=9",
   "colorlog<7",
+  "markdown2<3",
   "pyhafas==0.4",
   "python-dateutil<3",
 ]

--- a/rex/cli.py
+++ b/rex/cli.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2023, The Panodata developers and contributors.
 # Distributed under the terms of the AGPLv3 license, see LICENSE.
-
+import io
 import logging
+from contextlib import redirect_stdout
 
 import click as click
+import markdown2
 
-from rex.core import make_travelplan
+from rex.core import make_travelplan, compute_journey
 from rex.util.cli import boot_click, docstring_format_verbatim, split_list
 
 logger = logging.getLogger()
@@ -40,7 +42,44 @@ def cli(ctx: click.Context, verbose: bool, debug: bool):
 @click.option("--to", "destination", type=str, required=True)
 @click.option("--stops", "stops", type=str, required=False)
 @click.option("--on", "when", type=str, required=False)
+@click.option("--format", type=str, required=False, default="markdown")
 @click.pass_context
-def travel(ctx: click.Context, origin: str, destination: str, stops: str, when: str):
+def travel(ctx: click.Context, origin: str, destination: str, stops: str, when: str, format: str):
     logger.info(f"Computing journey from {origin} to {destination}")
-    make_travelplan(origin, destination, split_list(stops), when)
+    plan = make_travelplan(origin, destination, split_list(stops), when)
+    compute_journey(plan)
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        print("# Travel plan\n")
+        for segment in plan.locations:
+            print(f"## Connections from {segment.origin.name} to {segment.destination.name}")
+            print()
+            for journey in segment.travel_journeys:
+                print(f"### Duration {journey.duration} on {journey.date}")
+                for segment in journey.segments:
+                    print(f"- {segment.time}, {segment.transport}; {segment.details}")
+                print()
+            print()
+
+    buffer.seek(0)
+    markdown = buffer.read()
+
+    if format == "markdown":
+        print(markdown)
+    elif format == "html":
+        # print(markdown)
+        html_body = markdown2.markdown(markdown.encode("utf-8"))
+        html = f"""
+<html>
+<head>
+<meta charset="UTF-8">
+</head>
+<body>
+{html_body}
+</body>
+</html>
+        """
+        print(html)
+    else:
+        raise ValueError(f"Unknown output format: {format}")

--- a/rex/core.py
+++ b/rex/core.py
@@ -9,19 +9,25 @@ import datetime as dt
 from pyhafas import HafasClient
 from pyhafas.profile import DBProfile
 
-from rex.model import TravelLocation, TravelPlan
+from rex.model import TravelPlanLocation, TravelPlan, TravelJourney, TravelJourneySegment
 from rex.util.cli import split_list
-from rex.util.date import next_date_by_weekday, format_date_weekday
+from rex.util.date import next_date_by_weekday, format_date_weekday, format_time
 
 logger = logging.getLogger()
 
 
+# TODO: Make configurable.
 DEFAULT_DEPARTURE_TIME = dt.time(hour=9)
 DEFAULT_ARRIVAL_TIME = dt.time(hour=17)
 DEFAULT_STOP_DELTA = dt.timedelta(days=1)
+DEFAULT_MAX_CHANGES = -1
+DEFAULT_MIN_CHANGE_TIME = 3
 
 
 def make_travelplan(origin: str, destination: str, stops: t.List[str], when: str):
+    """
+    Obtain travel parameters and compute a travel plan draft.
+    """
     client = HafasClient(DBProfile())
 
     # Resolve home and remote locations.
@@ -45,24 +51,66 @@ def make_travelplan(origin: str, destination: str, stops: t.List[str], when: str
         f"with stops in {' and '.join(stops)} for {DEFAULT_STOP_DELTA.days} days each"
     )
 
-    # Build a travel plan draft, with home and remote locations, and eventual stops.
+    # Build a travel plan draft, with home and remote locations, and optional stops.
     plan = TravelPlan()
     if stops:
         location_start = location_home
         segment_departure = datetime_begin
         for stop in stops:
             location_stop = client.locations(stop)[0]
-            segment = TravelLocation(origin=location_start, destination=location_stop, departure=segment_departure)
+            segment = TravelPlanLocation(origin=location_start, destination=location_stop, departure=segment_departure)
             plan.append(segment)
             location_start = location_stop
             segment_departure += DEFAULT_STOP_DELTA
-        last_segment = TravelLocation(origin=location_start, destination=location_remote, departure=segment_departure)
+        last_segment = TravelPlanLocation(
+            origin=location_start, destination=location_remote, departure=segment_departure
+        )
         plan.append(last_segment)
     else:
-        towards = TravelLocation(origin=location_home, destination=location_remote, departure=datetime_begin)
-        plan.append(towards)
+        trip_outbound = TravelPlanLocation(origin=location_home, destination=location_remote, departure=datetime_begin)
+        plan.append(trip_outbound)
 
-    back = TravelLocation(origin=location_remote, destination=location_home, arrival=datetime_end)
-    plan.append(back)
+    trip_return = TravelPlanLocation(origin=location_remote, destination=location_home, arrival=datetime_end)
+    plan.append(trip_return)
 
-    logger.info(f"Travel plan draft: Locations\n{plan}")
+    logger.debug(f"Travel plan draft: Locations\n{plan}")
+
+    return plan
+
+
+def compute_journey(plan: TravelPlan):
+    """
+    Enrich travel plan draft with HAFAS journey information.
+    """
+    client = HafasClient(DBProfile())
+    for location in plan.locations:
+        location.hafas_journeys = client.journeys(
+            origin=location.origin,
+            destination=location.destination,
+            date=location.departure or location.arrival,
+            max_changes=DEFAULT_MAX_CHANGES,
+            min_change_time=DEFAULT_MIN_CHANGE_TIME,
+        )
+
+        for journey in location.hafas_journeys:
+            travel_journey = TravelJourney(duration=journey.duration, date=journey.date)
+            for leg in journey.legs:
+                label = str(leg.mode.value)
+                if leg.name:
+                    label += f" {leg.name}"
+
+                platforms = ""
+                if leg.departurePlatform is not None and leg.arrivalPlatform is not None:
+                    platforms = f"Platforms {leg.departurePlatform}/{leg.arrivalPlatform} "
+                details = f"{platforms}from {leg.origin.name} to {leg.destination.name}"
+
+                item = TravelJourneySegment(
+                    time=f"{format_time(leg.departure.time())}-{format_time(leg.arrival.time())}",
+                    transport=label,
+                    details=details,
+                )
+                if leg.departureDelay is not None or leg.arrivalDelay is not None:
+                    item.status = f"Delays: {leg.departureDelay} {leg.arrivalDelay}"
+                travel_journey.append(item)
+
+            location.travel_journeys.append(travel_journey)

--- a/rex/model.py
+++ b/rex/model.py
@@ -7,22 +7,32 @@ import io
 import json
 import typing as t
 
-from pyhafas.types.fptf import Station
+from pyhafas.types.fptf import Station, Journey
 
 
 @dataclasses.dataclass
-class TravelLocation:
+class TravelPlanLocation:
+    """
+    Represent a single travel location.
+    """
+
     origin: Station
     destination: Station
     departure: t.Optional[dt.datetime] = None
     arrival: t.Optional[dt.datetime] = None
+    hafas_journeys: t.List[Journey] = dataclasses.field(default_factory=list)
+    travel_journeys: t.List["TravelJourney"] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
 class TravelPlan:
-    locations: t.List[TravelLocation] = dataclasses.field(default_factory=list)
+    """
+    Represent multiple travel locations.
+    """
 
-    def append(self, *items: TravelLocation):
+    locations: t.List[TravelPlanLocation] = dataclasses.field(default_factory=list)
+
+    def append(self, *items: TravelPlanLocation):
         for item in items:
             self.locations.append(item)
 
@@ -35,3 +45,30 @@ class TravelPlan:
             buffer.write("\n")
         buffer.seek(0)
         return buffer.read()
+
+
+@dataclasses.dataclass
+class TravelJourneySegment:
+    """
+    Represent a single travel segment.
+    """
+
+    time: str
+    transport: str
+    details: str
+    status: t.Optional[str] = None
+
+
+@dataclasses.dataclass
+class TravelJourney:
+    """
+    Represent a whole travel journey.
+    """
+
+    duration: dt.timedelta
+    date: dt.date
+    segments: t.List[TravelJourneySegment] = dataclasses.field(default_factory=list)
+
+    def append(self, *items: TravelJourneySegment):
+        for item in items:
+            self.segments.append(item)

--- a/rex/util/date.py
+++ b/rex/util/date.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, The Panodata developers and contributors.
 # Distributed under the terms of the AGPLv3 license, see LICENSE.
 
+import typing as t
 import datetime as dt
 import dateutil.relativedelta as dtrel
 
@@ -33,3 +34,7 @@ def next_date_by_weekday(weekday: str, start=dt.date.today()):
 
 def format_date_weekday(datetime: dt.datetime):
     return f"{datetime} ({datetime.strftime('%A')})"
+
+
+def format_time(value: t.Union[dt.datetime, dt.time]) -> str:
+    return value.strftime("%H:%M")

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from rex.cli import cli
 
 
-def test_travel_example(caplog):
+def test_travel_ascii(caplog):
     """
     CLI test: Invoke example `rex travel` command.
     """
@@ -20,3 +20,20 @@ def test_travel_example(caplog):
     assert result.exit_code == 0
 
     assert "Travel plan draft: Locations" in caplog.text
+
+
+def test_travel_html(caplog):
+    """
+    CLI test: Invoke example `rex travel` command with HTML output.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        args="travel --from=Oranienburg --to=Kopenhagen --stops=Fürstenberg,Mildenberg --on=do-di --format=html",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    assert "Travel plan draft: Locations" in caplog.text
+    assert "<html>" in result.output


### PR DESCRIPTION
## About

Add basic querying of the HAFAS "journeys" API, and HTML output.

## Example outputs

### Markdown

```markdown
# Travel plan

## Connections from Oranienburg to Fürstenberg(Havel)

### Duration 0:31:00 on 2023-08-24
- 09:16-09:47, train RE 4354; Platforms 24/1 from Oranienburg to Fürstenberg(Havel)

### Duration 0:31:00 on 2023-08-24
- 10:16-10:47, train RE 3508; Platforms 24/1 from Oranienburg to Fürstenberg(Havel)

### Duration 0:31:00 on 2023-08-24
- 11:16-11:47, train RE 4356; Platforms 24/1 from Oranienburg to Fürstenberg(Havel)
```

### HTML
https://netfrag.org/~amo/test/rex/rex-travelplan-first.html
